### PR TITLE
chore(release): don't run tests as part of release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jobs:
   include:
     - stage: npm release
       node_js: "9"
+      script: echo "Deploying to npm…"
       deploy:
         provider: npm
         email: npmjs@squareup.com


### PR DESCRIPTION
They already run beforehand, so there's no need to do it again. The default script is `npm test`, so we simply override it with an informational message.