### PR TITLE
chore: add typescript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function findWorkspaceRoot(initial?: string | null | undefined): string | null;
+declare namespace findWorkspaceRoot {}
+export = findWorkspaceRoot;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/square/find-yarn-workspace-root.git"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "author": "Square, Inc.",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test": "mocha tests/**/*-test.js",
     "commitmsg": "commitlint -e $GIT_PARAMS"
   },
-  "files": [],
+  "files": [
+    "index.d.ts"
+  ],
   "dependencies": {
     "fs-extra": "^4.0.3",
     "micromatch": "^3.1.4"


### PR DESCRIPTION
Following my request in issue #12, this PR adds a TypeScript declaration file to this package. It can now be used in TypeScript with the following import (similar to many other older JS libraries like express).

```ts
import * as findWorkspaceRoot from "find-yarn-workspace-root";
```
