### PR TITLE
chore: remove unnecessary fs-extra dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const micromatch = require('micromatch');
 const path = require('path');
 
@@ -46,8 +46,8 @@ function extractWorkspaces(manifest) {
 
 function readPackageJSON(dir) {
   const file = path.join(dir, 'package.json');
-  if (fs.pathExistsSync(file)) {
-    return fs.readJsonSync(file);
+  if (fs.existsSync(file)) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "fs-extra": "^4.0.3",
     "micromatch": "^3.1.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,14 +684,6 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -777,7 +769,7 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.3:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1019,12 +1011,6 @@ js-yaml@^3.9.0:
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -1858,10 +1844,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
-
-universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Dependency was unnecessary. The methods `fs.readFileSync`, and `fs.existsSync` ship with Node since v0.1.8 and v0.1.21 respectively. `JSON.parse` is built into V8.

Related to RetireJS/retire.js/pull/253 and RetireJS/retire.js#241